### PR TITLE
fixed routing issues in include statements

### DIFF
--- a/dbTest.php
+++ b/dbTest.php
@@ -1,3 +1,3 @@
 <?php
-  include "db.php";
+  include "includes/db.php";
  ?>

--- a/includes/bottom.php
+++ b/includes/bottom.php
@@ -3,6 +3,6 @@
   integrity="sha256-16cdPddA6VdVInumRGo6IbivbERE8p7CQR3HzTBuELA="
   crossorigin="anonymous"></script>
 <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="../js/checkbox.js"></script>
+<script type="text/javascript" src="js/checkbox.js"></script>
 </body>
 </html>

--- a/includes/top.php
+++ b/includes/top.php
@@ -9,4 +9,4 @@
      <link rel="stylesheet" href="css/login.css" type="text/css">
   </head>
   <body>
-    <?php include "C:/xampp/htdocs/Books/includes/navbar.php"; ?>
+    <?php include "navbar.php"; ?>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
-<?php include "C:/xampp/htdocs/Books/includes/top.php" ?>
+<?php include "includes/top.php" ?>
 
 
 
-<?php include "C:/xampp/htdocs/Books/includes/footer.php" ?>
+<?php include "includes/bottom.php" ?>

--- a/login.php
+++ b/login.php
@@ -1,5 +1,5 @@
-<?php include "C:/xampp/htdocs/Books/includes/top.php" ?>
-<?php include "C:/xampp/htdocs/Books/includes/db.php" ?>
+<?php include "includes/top.php" ?>
+<?php include "includes/db.php" ?>
 <?php
 if(isset($_POST['submit'])) {
   if(DB::IsAuthenticated($_POST['username'], $_POST['password'])) {
@@ -21,4 +21,4 @@ if(isset($_POST['submit'])) {
     <input type="submit" name="submit" class="btn btn-success login-button" value="Login"></button>
   </form>
 </div>
-<?php include "C:/xampp/htdocs/Books/includes/bottom.php" ?>
+<?php include "includes/bottom.php" ?>

--- a/register.php
+++ b/register.php
@@ -1,5 +1,5 @@
-<?php include "C:/xampp/htdocs/Books/includes/top.php" ?>
-<?php include "C:/xampp/htdocs/Books/includes/db.php" ?>
+<?php include "includes/top.php" ?>
+<?php include "includes/db.php" ?>
 
 <?php
 if(isset($_POST['submit'])) {
@@ -69,4 +69,4 @@ if(isset($_POST['submit'])) {
   </form>
 </div>
 
-<?php include "../includes/bottom.php" ?>
+<?php include "includes/bottom.php" ?>

--- a/register_book.php
+++ b/register_book.php
@@ -1,7 +1,7 @@
 <?php
     // register_book.php
-    include "C:/xampp/htdocs/Books/includes/db.php";
-    include "C:/xampp/htdocs/Books/includes/top.php";
+    include "includes/db.php";
+    include "includes/top.php";
  ?>
 
 <div class="container main-content">


### PR DESCRIPTION
A lot of your includes were Windows specific, which won't translate to a server. This way PHP starts looking at the root of the directory, not the file system.